### PR TITLE
GetString methods for enums

### DIFF
--- a/BM-RCON/BM_RCON_lib/RCON_Client.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Client.cs
@@ -225,7 +225,7 @@ namespace BM_RCON.BM_RCON_lib
 
                     rcon_evt = ParsePacket(packet_received);
 
-                    logger.LogDebug($"Event ({rcon_evt.EventID}) received.");
+                    logger.LogDebug($"Event {(EventType)rcon_evt.EventID} ({rcon_evt.EventID}) received.");
                 }
             }
             catch (Exception e)

--- a/BM-RCON/BM_RCON_lib/enums/BotDifficulties.cs
+++ b/BM-RCON/BM_RCON_lib/enums/BotDifficulties.cs
@@ -12,4 +12,18 @@
         cruel = 3,
         random = 4
     }
+
+    static class BotDifficultyExtension
+    {
+        /// <summary>
+        /// Extension method to get the string associated to a BotDifficulty
+        /// </summary>
+        /// <param name="difficulty">The bot difficulty</param>
+        /// <returns>The bot difficulty as a readable string</returns>
+        public static string GetString(this BotDifficulty difficulty)
+        {
+            string[] difficulties = { "Easy", "Normal", "Hard", "Cruel", "Random" };
+            return difficulties[(int)difficulty];
+        }
+    }
 }

--- a/BM-RCON/BM_RCON_lib/enums/Enemies.cs
+++ b/BM-RCON/BM_RCON_lib/enums/Enemies.cs
@@ -52,4 +52,43 @@
         powerful = 3,
         god_like = 4
     }
+
+    static class EnemyExtension
+    {
+        /// <summary>
+        /// Extension method to get the string associated to an Enemy
+        /// </summary>
+        /// <param name="enemy">The enemy</param>
+        /// <returns>The enemy as a readable string</returns>
+        public static string GetString(this Enemy enemy)
+        {
+            string[] enemies = {
+                "Cannibal", "Hopper", "Blue Soldier",
+                "Purple", "Sniper", "Flesheater",
+                "Blue Lieutenant", "Fuschia", "Leaper",
+                "Bomb Dude", "Demolition Guy", "Ninja",
+                "Samurai", "Indigo", "Blue Captain",
+                "Grandmaster", "EXPLODEBOT 5000", "Anthropophagite",
+                "Moxxy", "Roxxy", "Disciple",
+                "Manling", "Operator", "Cowboy",
+                "Archer", "Zombie", "Zhost",
+                "Zpitter", "Zomikaze", "Doctor"
+            };
+            return enemies[(int)enemy];
+        }
+
+        /// <summary>
+        /// Extension method to get the string associated to a Rank
+        /// </summary>
+        /// <param name="rank">The rank</param>
+        /// <returns>The rank as a readable string</returns>
+        public static string GetString(this Rank rank)
+        {
+            string[] ranks = {
+                "Normal", "Strong", "Elite",
+                "Powerful", "God-like"
+            };
+            return ranks[(int)rank];
+        }
+    }
 }

--- a/BM-RCON/BM_RCON_lib/enums/PowerUps.cs
+++ b/BM-RCON/BM_RCON_lib/enums/PowerUps.cs
@@ -12,4 +12,21 @@
         // not implemented yet
         //bfg = 5
     }
+
+    static class PowerUpExtension
+    {
+        /// <summary>
+        /// Extension method to get the string associated to a PowerUp
+        /// </summary>
+        /// <param name="power">The power up</param>
+        /// <returns>The power up as a readable string</returns>
+        public static string GetString(this PowerUp power)
+        {
+            string[] powers = {
+                "Triple Damage", "Super Speed",
+                "Regeneration", "Invisibility"
+            };
+            return powers[(int)power];
+        }
+    }
 }

--- a/BM-RCON/BM_RCON_lib/enums/RequestTypes.cs
+++ b/BM-RCON/BM_RCON_lib/enums/RequestTypes.cs
@@ -1,12 +1,15 @@
 ﻿namespace BM_RCON.BM_RCON_lib
 {
     /// <summary>
-    /// Enum for request types
+    /// Enum for request types (cf <see href="https://github.com/Spasman/rcon_example#sending-requests-and-processing-request_data">Spasman's docs</see>)
     /// </summary>
     enum RequestType : short
     {
         login = 0,
         ping = 1,
+        /// <summary>
+        /// Cf <see href="https://github.com/ShaigroRB/bm-boilerplate#additional-server-commands-you-can-send-these-packets-via-rcon-besides-the-request-data-ones">server commands</see> from Coyote's boilerplate
+        /// </summary>
         command = 2,
         request_player = 3,
         request_bounce = 4,

--- a/BM-RCON/BM_RCON_lib/enums/Teams.cs
+++ b/BM-RCON/BM_RCON_lib/enums/Teams.cs
@@ -10,4 +10,18 @@
         the_man = 2,
         spectators = 3
     }
+
+    static class TeamExtension
+    {
+        /// <summary>
+        /// Extension method to get the string associated to a Team
+        /// </summary>
+        /// <param name="team">The team</param>
+        /// <returns>The team as a readable string</returns>
+        public static string GetString(this Team team)
+        {
+            string[] teams = { "None", "USC", "The Man", "SPECTATORS" };
+            return teams[(int)team];
+        }
+    }
 }

--- a/BM-RCON/BM_RCON_lib/enums/Vices.cs
+++ b/BM-RCON/BM_RCON_lib/enums/Vices.cs
@@ -49,4 +49,34 @@
         super_antacids = 41,
         indigos_reserve = 42
     }
+
+    static class ViceExtension
+    {
+        /// <summary>
+        /// Extension method to get the string associated to a Vice
+        /// </summary>
+        /// <param name="vice">The vice</param>
+        /// <returns>The vice as a readable string</returns>
+        public static string GetString(this Vice vice)
+        {
+            string[] vices = {
+                "Lager", "Cider", "Ale",
+                "Moonshine", "Red Wine", "Whiskey",
+                "Martini", "Jägerbomb", "Tequila",
+                "Joint", "Stout", "Margarita",
+                "Gin & Tonic", "Bloody Mary", "Screwdriver",
+                "Saké", "Mead", "White Wine",
+                "Cigar", "Varian Cigar", "Porter",
+                "Energy Drink", "Painkillers", "Mojito",
+                "Bourbon & Cola", "Beer", "Spliff",
+                "Stimulants", "Absinthe", "Rum",
+                "Champagne", "Vape Pen", "Sherry",
+                "Espresso", "Water", "Rubbing Alcohol",
+                "Hot Wings", "Antacids", "Smokes",
+                "Vodka", "Maria", "Super Antacids",
+                "Indigo's Reserve"
+            };
+            return vices[(int)vice];
+        }
+    }
 }

--- a/BM-RCON/BM_RCON_lib/enums/Weapons.cs
+++ b/BM-RCON/BM_RCON_lib/enums/Weapons.cs
@@ -44,7 +44,7 @@
         machine_gun = 36,
         // nothing = 37,
         grenade_launcher = 38,
-        heavy_grenade_launcher = 39,
+        heavy_gl = 39,
         // nothing = 40,
         rocket_launcher = 41,
         light_rocket = 42,
@@ -85,5 +85,47 @@
         kunai = 77,
         jetpack = 78,
         boomerang = 79
+    }
+
+    static class WeaponExtension
+    {
+        /// <summary>
+        /// Extension method to get the string associated to a Weapon
+        /// </summary>
+        /// <param name="weapon">The weapon</param>
+        /// <returns>The weapon as a readable string</returns>
+        public static string GetString(this Weapon weapon)
+        {
+            string[] weapons = {
+                "Fists", "", "Pistol",
+                "Silenced Pistol", "Underwater Pistol", "Revolver",
+                "Burst Pistol", "Compact Pistol", "Handcannon",
+                "Uzi", "Compact Uzi", "Fire Uzi",
+                "Light SMG", "SMG", "Power SMG",
+                "Power SMG", "", "Sawn-Off",
+                "Pump Action", "Double Barrel", "Trench Gun",
+                "", "Light AR", "Assault Rifle", "Keymaster",
+                "Heal Rifle", "Underwater Rifle", "Musket",
+                "Power Rifle", "Long Rifle", "Scoped Rifle",
+                "Lever Action", "Plinger", "Sniper Rifle",
+                "Bolt Action", "", "",
+                "Machine Gun", "", "Grenade Launcher",
+                "Heavy GL", "", "Rocket Launcher",
+                "Light Rockets", "", "",
+                "Acid Gun", "", "Muleslapper",
+                "", "Bow", "Crossbow",
+                "Grapplehook", "Knife", "Sword",
+                "Wrench", "", "Magic",
+                "Railgun", "", "",
+                "", "Drone", "Frag",
+                "Potato Masher", "EMP", "Molotov",
+                "Nitrogen Mine", "Heal Grenade", "Gas Grenade",
+                "Flashbang", "Muleslapper Sentry", "Tomahawk",
+                "Suicide Vest", "Skateboard", "Pineapple",
+                "Scuba Gear", "Dynamite", "Kunai",
+                "Jetpack", "Boomerang"
+            };
+            return weapons[(int)weapon];
+        }
     }
 }


### PR DESCRIPTION
- Some console commands can use string values. A GetString method has been added for the enums that can be used as string in the commands.
- Add docs to RequestType enum
- Log the name of the event in addition to the eventID for debugging