### PR TITLE
Different log levels

### DIFF
--- a/BM-RCON/BM_RCON_lib/RCON_Client.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Client.cs
@@ -29,6 +29,7 @@ namespace BM_RCON.BM_RCON_lib
         /// <param name="logger">The logger used</param>
         public RCON_Client(string addr, int port, string password, ILogger logger)
         {
+            logger.Debug($"A client connecting to {addr}:{port} is instanciating.");
             this.address = addr;
             this.port = port;
             this.password = password;
@@ -36,6 +37,7 @@ namespace BM_RCON.BM_RCON_lib
 
             UTF8Encoding uTF8 = new UTF8Encoding();
             this.start_del_bytes = uTF8.GetBytes("┐");
+            logger.Trace("Finished instanciating the client.");
         }
 
         /// <summary>
@@ -44,17 +46,22 @@ namespace BM_RCON.BM_RCON_lib
         /// <returns>Returns 0 if successfully connected, otherwise returns 1</returns>
         public int Connect()
         {
+            logger.Trace("RCON_Client.Connect() starts.");
             int status;
             try
             {
-                logger.Info($"Connecting to {address}:{port} using '{password}' as password...");
+                logger.Info($"Connecting to {address}:{port} using '{password[0]}..' as password...");
 
+                logger.Debug($"Instanciating TCPClient on {address}:{port}");
                 // no method to reconnect, let's instanciate one each time...
                 this.client = new TcpClient(this.address, this.port);
 
+                logger.Trace("Getting stream from the client.");
                 NetworkStream stream = this.client.GetStream();
+                logger.Trace("Setting timeout of stream's writing to 7000ms.");
                 stream.WriteTimeout = 7000;
 
+                logger.Trace($"Send request to login with '{password[0]}..' as password");
                 status = SendRequest(RequestType.login, this.password);
                 if (status == 1)
                 {
@@ -68,9 +75,10 @@ namespace BM_RCON.BM_RCON_lib
             catch (Exception e)
             {
                 logger.Fatal("Failed to connect.");
-                logger.Fatal($"Error: {e.ToString()}");
+                logger.Debug($"Error: {e.ToString()}");
                 status = 1;
             }
+            logger.Trace("RCON_Client.Connect() finishes.");
             return status;
         }
 
@@ -79,8 +87,11 @@ namespace BM_RCON.BM_RCON_lib
         /// </summary>
         public void Disconnect()
         {
+            logger.Trace("RCON_Client.Disconnect() starts.");
+            logger.Debug($"Closing the client opened on {address}:{port}");
             this.client.Close();
-            logger.Info($"Client {address}:{port} disconnected.");
+            logger.Info($"Client on {address}:{port} disconnected.");
+            logger.Trace("RCON_Client.Disconnect() finishes.");
         }
 
         /// <summary>
@@ -91,6 +102,7 @@ namespace BM_RCON.BM_RCON_lib
         /// <returns>Returns the packet</returns>
         public byte[] CreatePacket(RequestType RequestType, string body)
         {
+            logger.Trace("RCON_Client.CreatePacket(type, body) starts.");
             /*
              * final_packet is a concatenation of:
              * - a short (16-bit integer) corresponding to the request's type
@@ -102,25 +114,31 @@ namespace BM_RCON.BM_RCON_lib
             UTF8Encoding uTF8 = new UTF8Encoding();
 
             // convert into bytes
+            logger.Trace("Converting the request type to bytes.");
             byte[] req_type_bytes = BitConverter.GetBytes(req_type);
+            logger.Trace("Converting the body to bytes.");
             byte[] body_bytes = uTF8.GetBytes(body);
 
             // final packet
             // + 1 at the end to add a null byte
+            logger.Trace("Creating the final packet.");
             byte[] final_packet = new byte[req_type_bytes.Length + body_bytes.Length + 1];
 
             int byte_ptr = 0;
 
             // copy bytes to final packet
+            logger.Trace("Copying the request type to the final packet.");
             req_type_bytes.CopyTo(final_packet, byte_ptr);
             byte_ptr += req_type_bytes.Length;
 
+            logger.Trace("Copying the body to the final packet.");
             body_bytes.CopyTo(final_packet, byte_ptr);
             byte_ptr += body_bytes.Length;
 
             // don't forget the last null byte
             final_packet[byte_ptr] = (byte)0;
 
+            logger.Trace("RCON_Client.CreatePacket(type, body) finishes.");
             return final_packet;
         }
 
@@ -131,6 +149,7 @@ namespace BM_RCON.BM_RCON_lib
         /// <returns>Returns a RCON_Event object</returns>
         public RCON_Event ParsePacket(byte[] pckt_bytes)
         {
+            logger.Trace("RCON_Client.ParsePacket(bytes) starts.");
             /*
              * pckt_bytes is a concatenation of:
              * - the start delimiter "┐"
@@ -148,17 +167,22 @@ namespace BM_RCON.BM_RCON_lib
             // number of bytes for 16-bit integer
             int short_bytes = 2;
 
+            logger.Trace("Getting JSON size from the packet as bytes.");
             // convert bytes to short
             short json_size = BitConverter.ToInt16(pckt_bytes, byte_ptr);
             byte_ptr += short_bytes;
+            logger.Trace("Getting event ID from the packet as bytes.");
             short eventID = BitConverter.ToInt16(pckt_bytes, byte_ptr);
             byte_ptr += short_bytes;
 
+            logger.Trace("Get the JSON from the packet as bytes.");
             // get json as string from bytes and remove the end delimiter
             string pckt_json = uTF8.GetString(pckt_bytes, byte_ptr, json_size).TrimEnd('└');
 
+            logger.Debug($"Creation of RCON_Event with json size: {json_size}, ID: {eventID}, json: {pckt_json}");
             RCON_Event rcon_event = new RCON_Event(json_size, eventID, pckt_json, logger);
 
+            logger.Trace("RCON_Client.ParsePacket(bytes) finishes.");
             return rcon_event;
         }
 
@@ -169,21 +193,26 @@ namespace BM_RCON.BM_RCON_lib
         /// <returns>Returns 0 if the request was successfully sent, otherwise returns 1</returns>
         public int SendRequest(byte[] req)
         {
+            logger.Trace("RCON_Client.SendRequest(bytes) starts.");
             int status = 0;
             try
             {
+                logger.Trace("Getting stream from the client.");
                 NetworkStream stream = this.client.GetStream();
+                logger.Trace("Setting timeout of stream's writing to 7000ms.");
                 stream.WriteTimeout = 7000;
+                logger.Trace("Writing on the stream.");
                 stream.Write(req, 0, req.Length);
 
-                logger.Debug($"Request ({Encoding.UTF8.GetString(req)}) sent.");
+                logger.Trace($"Writing on the stream successful.");
             }
             catch (Exception e)
             {
                 logger.Error("Failed to send a request.");
-                logger.Error($"Error: {e.ToString()}");
+                logger.Debug($"Error: {e.ToString()}");
                 status = 1;
             }
+            logger.Trace("RCON_Client.SendRequest(bytes) finishes.");
             return status;
         }
 
@@ -195,12 +224,24 @@ namespace BM_RCON.BM_RCON_lib
         /// <returns>Returns 0 if the request was successfully sent, otherwise returns 1</returns>
         public int SendRequest(RequestType req_type, string body)
         {
+            logger.Trace("RCON_Client.SendRequest(type, body) starts.");
+            logger.Trace($"Creating packet of type: {req_type.ToString()}, body: {body}");
             byte[] pckt = CreatePacket(req_type, body);
+
+            logger.Trace("Packet created.");
+            logger.Trace("Sending request.");
             int status = SendRequest(pckt);
+
+            logger.Trace("Checking if the request was successfully sent to the server.");
             if (status == 1)
             {
                 logger.Error($"Failed to send request of type {req_type.ToString()} and of body {body}");
             }
+            else
+            {
+                logger.Debug($"Request of type {req_type.ToString()} and body {body} sent to the server.");
+            }
+            logger.Trace("RCON_Client.SendRequest(type, body) finishes.");
             return status;
         }
 
@@ -210,30 +251,37 @@ namespace BM_RCON.BM_RCON_lib
         /// <returns>Returns a RCON_Event if successfully received the next event, otherwise returns null</returns>
         public RCON_Event ReceiveEvent()
         {
+            logger.Trace("RCON_Client.ReceiveEvent() starts.");
             RCON_Event rcon_evt = null;
             try
             {
+                logger.Trace("Getting stream from the client.");
                 // always get stream, and do not close it afterwards
                 NetworkStream stream = this.client.GetStream();
+                logger.Trace("Setting timeout of stream's reading to 7000ms.");
                 stream.ReadTimeout = 7000;
 
                 byte[] packet_received = new byte[this.client.ReceiveBufferSize];
                 if (this.client.ReceiveBufferSize > 0)
                 {
+                    logger.Trace("Reading data from the stream.");
                     // reads data from stream and put it in the buffer "packet_received"
                     stream.Read(packet_received, 0, packet_received.Length);
 
+                    logger.Trace("Parsing the data received and create a new event from it.");
                     rcon_evt = ParsePacket(packet_received);
 
                     logger.Debug($"Event {(EventType)rcon_evt.EventID} ({rcon_evt.EventID}) received.");
                 }
+                logger.Trace("Finished checking for data in the stream");
             }
             catch (Exception e)
             {
                 logger.Error("Failed to receive event.");
-                logger.Error($"Error: {e.ToString()}");
+                logger.Debug($"Error: {e.ToString()}");
             }
 
+            logger.Trace("RCON_Client.ReceiveEvent() finishes.");
             return rcon_evt;
         }
     }

--- a/BM-RCON/BM_RCON_lib/RCON_Client.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Client.cs
@@ -29,7 +29,7 @@ namespace BM_RCON.BM_RCON_lib
         /// <param name="logger">The logger used</param>
         public RCON_Client(string addr, int port, string password, ILogger logger)
         {
-            logger.Debug($"A client connecting to {addr}:{port} is instanciating.");
+            logger.Trace($"A client connecting to {addr}:{port} is instanciating.");
             this.address = addr;
             this.port = port;
             this.password = password;
@@ -52,7 +52,7 @@ namespace BM_RCON.BM_RCON_lib
             {
                 logger.Info($"Connecting to {address}:{port} using '{password[0]}..' as password...");
 
-                logger.Debug($"Instanciating TCPClient on {address}:{port}");
+                logger.Debug($"Creating a client for {address}:{port}");
                 // no method to reconnect, let's instanciate one each time...
                 this.client = new TcpClient(this.address, this.port);
 
@@ -179,7 +179,7 @@ namespace BM_RCON.BM_RCON_lib
             // get json as string from bytes and remove the end delimiter
             string pckt_json = uTF8.GetString(pckt_bytes, byte_ptr, json_size).TrimEnd('└');
 
-            logger.Debug($"Creation of RCON_Event with json size: {json_size}, ID: {eventID}, json: {pckt_json}");
+            logger.Trace($"Creating an event.");
             RCON_Event rcon_event = new RCON_Event(json_size, eventID, pckt_json, logger);
 
             logger.Trace("RCON_Client.ParsePacket(bytes) finishes.");
@@ -239,7 +239,7 @@ namespace BM_RCON.BM_RCON_lib
             }
             else
             {
-                logger.Debug($"Request of type {req_type.ToString()} and body {body} sent to the server.");
+                logger.Debug($"Request of type: {req_type.ToString()}, body: '{body}' sent to the server.");
             }
             logger.Trace("RCON_Client.SendRequest(type, body) finishes.");
             return status;

--- a/BM-RCON/BM_RCON_lib/RCON_Client.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Client.cs
@@ -47,7 +47,7 @@ namespace BM_RCON.BM_RCON_lib
             int status;
             try
             {
-                logger.LogInfo($"Connecting to {address}:{port} using '{password}' as password...");
+                logger.Info($"Connecting to {address}:{port} using '{password}' as password...");
 
                 // no method to reconnect, let's instanciate one each time...
                 this.client = new TcpClient(this.address, this.port);
@@ -58,17 +58,17 @@ namespace BM_RCON.BM_RCON_lib
                 status = SendRequest(RequestType.login, this.password);
                 if (status == 1)
                 {
-                    logger.LogWarning("Failed to connect.");
+                    logger.Error("Failed to connect.");
                 }
                 else
                 {
-                    logger.LogInfo("Connection successful.");
+                    logger.Info("Connection successful.");
                 }
             }
             catch (Exception e)
             {
-                logger.LogError("Failed to connect.");
-                logger.LogError($"Error: {e.ToString()}");
+                logger.Fatal("Failed to connect.");
+                logger.Fatal($"Error: {e.ToString()}");
                 status = 1;
             }
             return status;
@@ -80,7 +80,7 @@ namespace BM_RCON.BM_RCON_lib
         public void Disconnect()
         {
             this.client.Close();
-            logger.LogInfo($"Client {address}:{port} disconnected.");
+            logger.Info($"Client {address}:{port} disconnected.");
         }
 
         /// <summary>
@@ -176,12 +176,12 @@ namespace BM_RCON.BM_RCON_lib
                 stream.WriteTimeout = 7000;
                 stream.Write(req, 0, req.Length);
 
-                logger.LogDebug($"Request ({Encoding.UTF8.GetString(req)}) sent.");
+                logger.Debug($"Request ({Encoding.UTF8.GetString(req)}) sent.");
             }
             catch (Exception e)
             {
-                logger.LogError("Failed to send a request.");
-                logger.LogError($"Error: {e.ToString()}");
+                logger.Error("Failed to send a request.");
+                logger.Error($"Error: {e.ToString()}");
                 status = 1;
             }
             return status;
@@ -199,7 +199,7 @@ namespace BM_RCON.BM_RCON_lib
             int status = SendRequest(pckt);
             if (status == 1)
             {
-                logger.LogWarning($"Failed to send request of type {req_type.ToString()} and of body {body}");
+                logger.Error($"Failed to send request of type {req_type.ToString()} and of body {body}");
             }
             return status;
         }
@@ -225,13 +225,13 @@ namespace BM_RCON.BM_RCON_lib
 
                     rcon_evt = ParsePacket(packet_received);
 
-                    logger.LogDebug($"Event {(EventType)rcon_evt.EventID} ({rcon_evt.EventID}) received.");
+                    logger.Debug($"Event {(EventType)rcon_evt.EventID} ({rcon_evt.EventID}) received.");
                 }
             }
             catch (Exception e)
             {
-                logger.LogError("Failed to receive event.");
-                logger.LogError($"Error: {e.ToString()}");
+                logger.Error("Failed to receive event.");
+                logger.Error($"Error: {e.ToString()}");
             }
 
             return rcon_evt;

--- a/BM-RCON/BM_RCON_lib/RCON_Event.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Event.cs
@@ -21,7 +21,7 @@ namespace BM_RCON.BM_RCON_lib
         /// <param name="logger">The logger used</param>
         public RCON_Event(short json_size, short eventID, string json, ILogger logger)
         {
-            logger.Debug("Instanciation of an event.");
+            logger.Trace("Instanciation of an event.");
 
             logger.Trace($"JSON size: {json_size}, id: {eventID}, json: {json}");
             // the json size takes into account the end delimiter which length is 3 bits

--- a/BM-RCON/BM_RCON_lib/RCON_Event.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Event.cs
@@ -59,9 +59,9 @@ namespace BM_RCON.BM_RCON_lib
         /// </summary>
         public void Print()
         {
-            logger.LogInfo("JSON size: " + JsonSize.ToString());
-            logger.LogInfo("Event ID: " + EventID.ToString());
-            logger.LogInfo("JSON: " + JsonAsString);
+            logger.Info("JSON size: " + JsonSize.ToString());
+            logger.Info("Event ID: " + EventID.ToString());
+            logger.Info("JSON: " + JsonAsString);
         }
     }
 }

--- a/BM-RCON/BM_RCON_lib/RCON_Event.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Event.cs
@@ -22,18 +22,15 @@ namespace BM_RCON.BM_RCON_lib
         public RCON_Event(short json_size, short eventID, string json, ILogger logger)
         {
             logger.Debug("Instanciation of an event.");
-            logger.Trace("Instanciation of an event.");
 
-            logger.Trace($"JSON size: {json_size}");
+            logger.Trace($"JSON size: {json_size}, id: {eventID}, json: {json}");
             // the json size takes into account the end delimiter which length is 3 bits
             // real size of the json is json - 3
             this.JsonSize = json_size;
 
-            logger.Trace($"ID: {eventID}");
             // the event ID is in also in the json, if needed
             this.EventID = eventID;
 
-            logger.Trace($"json: {json}");
             // json as string
             this.JsonAsString = json;
 
@@ -70,11 +67,12 @@ namespace BM_RCON.BM_RCON_lib
         /// </summary>
         public void Print()
         {
-            logger.Trace("Print function called.");
+            logger.Trace("RCON_Event.Print() starts.");
             logger.Debug("Printing the event info of an event.");
             logger.Info("JSON size: " + JsonSize.ToString());
             logger.Info("Event ID: " + EventID.ToString());
             logger.Info("JSON: " + JsonAsString);
+            logger.Trace("RCON_Event.Print() finishes.");
         }
     }
 }

--- a/BM-RCON/BM_RCON_lib/RCON_Event.cs
+++ b/BM-RCON/BM_RCON_lib/RCON_Event.cs
@@ -21,17 +21,28 @@ namespace BM_RCON.BM_RCON_lib
         /// <param name="logger">The logger used</param>
         public RCON_Event(short json_size, short eventID, string json, ILogger logger)
         {
+            logger.Debug("Instanciation of an event.");
+            logger.Trace("Instanciation of an event.");
+
+            logger.Trace($"JSON size: {json_size}");
             // the json size takes into account the end delimiter which length is 3 bits
             // real size of the json is json - 3
             this.JsonSize = json_size;
+
+            logger.Trace($"ID: {eventID}");
             // the event ID is in also in the json, if needed
             this.EventID = eventID;
+
+            logger.Trace($"json: {json}");
             // json as string
             this.JsonAsString = json;
+
+            logger.Trace("Parsing the json as an object.");
             // json as object
             this.JsonAsObj = JObject.Parse(json);
             // logger used for Print method
             this.logger = logger;
+            logger.Trace("Finished the instanciation of the event.");
         }
 
         /// <summary>
@@ -59,6 +70,8 @@ namespace BM_RCON.BM_RCON_lib
         /// </summary>
         public void Print()
         {
+            logger.Trace("Print function called.");
+            logger.Debug("Printing the event info of an event.");
             logger.Info("JSON size: " + JsonSize.ToString());
             logger.Info("Event ID: " + EventID.ToString());
             logger.Info("JSON: " + JsonAsString);

--- a/BM-RCON/BM_RCON_lib/interfaces/ILogger.cs
+++ b/BM-RCON/BM_RCON_lib/interfaces/ILogger.cs
@@ -13,49 +13,63 @@ namespace BM_RCON.BM_RCON_lib
         void Log(string msg);
 
         /// <summary>
+        /// Trace logging (highest verbosity)
+        /// </summary>
+        /// <param name="msg">Message to log</param>
+        void Trace(string msg);
+
+        /// <summary>
+        /// Debug logging
+        /// </summary>
+        /// <param name="msg">Message to log</param>
+        void Debug(string msg);
+
+        /// <summary>
         /// Info logging
         /// </summary>
         /// <param name="msg">Message to log</param>
-        void LogInfo(string msg);
-
-        /// <summary>
-        /// Debug logging (only if debug is enabled)
-        /// </summary>
-        /// <param name="msg">Message to log</param>
-        void LogDebug(string msg);
-
-        /// <summary>
-        /// Error logging
-        /// </summary>
-        /// <param name="msg">Message to log</param>
-        void LogError(string msg);
+        void Info(string msg);
 
         /// <summary>
         /// Warning logging
         /// </summary>
         /// <param name="msg">Message to log</param>
-        void LogWarning(string msg);
+        void Warning(string msg);
 
         /// <summary>
-        /// Enable debug logging
+        /// Error logging
         /// </summary>
-        void EnableDebug();
+        /// <param name="msg">Message to log</param>
+        void Error(string msg);
 
         /// <summary>
-        /// Disable debug logging
+        /// Fatal logging
         /// </summary>
-        void DisableDebug();
+        /// <param name="msg">Message to log</param>
+        void Fatal(string msg);
 
         /// <summary>
-        /// Toggle debug logging
+        /// Set state of debug logging
         /// </summary>
-        /// <returns>Returns current state of debug logging</returns>
-        bool ToggleDebug();
+        /// <param name="state">The state to set</param>
+        void SetDebug(bool state);
 
         /// <summary>
-        /// State of debug logging
+        /// Check if debug is enabled
         /// </summary>
         /// <returns>Returns current state of debug logging</returns>
         bool IsDebugEnabled();
+
+        /// <summary>
+        /// Set state of trace logging
+        /// </summary>
+        /// <param name="state">The state to set</param>
+        void SetTrace(bool state);
+
+        /// <summary>
+        /// Check if trace is enabled
+        /// </summary>
+        /// <returns>Returns current state of trace logging</returns>
+        bool IsTraceEnabled();
     }
 }

--- a/BM-RCON/BM_RCON_lib/loggers/ConsoleLogger.cs
+++ b/BM-RCON/BM_RCON_lib/loggers/ConsoleLogger.cs
@@ -40,6 +40,10 @@ namespace BM_RCON.BM_RCON_lib
             {
                 Log($"[DEBUG] {msg}");
             }
+            else if (isTrace)
+            {
+                Log($"[TRACE] {msg}");
+            }
         }
 
         public void Info(string msg)

--- a/BM-RCON/BM_RCON_lib/loggers/ConsoleLogger.cs
+++ b/BM-RCON/BM_RCON_lib/loggers/ConsoleLogger.cs
@@ -7,21 +7,59 @@ namespace BM_RCON.BM_RCON_lib
     /// </summary>
     class ConsoleLogger : ILogger
     {
+        private bool isTrace;
         private bool isDebug;
 
-        public ConsoleLogger(bool isDebug = true)
+        /// <summary>
+        /// Initialize a ConsoleLogger
+        /// </summary>
+        /// <param name="isDebug">Set if Debug verbosity is enabled</param>
+        /// <param name="isTrace">Set if Trace verbosity is enabled</param>
+        public ConsoleLogger(bool isDebug = false, bool isTrace = false)
         {
+            this.isTrace = isTrace;
             this.isDebug = isDebug;
         }
 
-        public void DisableDebug()
+        public void Log(string msg)
         {
-            isDebug = false;
+            Console.WriteLine($"{DateTime.UtcNow} {msg}");
         }
 
-        public void EnableDebug()
+        public void Trace(string msg)
         {
-            isDebug = true;
+            if (isTrace)
+            {
+                Log($"[TRACE] {msg}");
+            }
+        }
+
+        public void Debug(string msg)
+        {
+            if (isDebug)
+            {
+                Log($"[DEBUG] {msg}");
+            }
+        }
+
+        public void Info(string msg)
+        {
+            Log($"[INFO] {msg}");
+        }
+
+        public void Warning(string msg)
+        {
+            Log($"[WARNING] {msg}");
+        }
+
+        public void Error(string msg)
+        {
+            Log($"[ERROR] {msg}");
+        }
+
+        public void Fatal(string msg)
+        {
+            Log($"[FATAL] {msg}");
         }
 
         public bool IsDebugEnabled()
@@ -29,38 +67,19 @@ namespace BM_RCON.BM_RCON_lib
             return isDebug;
         }
 
-        public void Log(string msg)
+        public bool IsTraceEnabled()
         {
-            Console.WriteLine(msg);
+            return isTrace;
         }
 
-        public void LogDebug(string msg)
+        public void SetDebug(bool state)
         {
-            if (isDebug)
-            {
-                Console.WriteLine("[DEBUG]: {0}", msg);
-            }
+            isDebug = state;
         }
 
-        public void LogError(string msg)
+        public void SetTrace(bool state)
         {
-            Console.WriteLine("[ERROR]: {0}", msg);
-        }
-
-        public void LogInfo(string msg)
-        {
-            Console.WriteLine("[INFO]: {0}", msg);
-        }
-
-        public void LogWarning(string msg)
-        {
-            Console.WriteLine("[WARNING]: {0}", msg);
-        }
-
-        public bool ToggleDebug()
-        {
-            isDebug = !isDebug;
-            return isDebug;
+            isTrace = state;
         }
     }
 }

--- a/BM-RCON/Program.cs
+++ b/BM-RCON/Program.cs
@@ -19,13 +19,12 @@ namespace BM_RCON
         {
             Thread.Sleep(160);
             rcon.SendRequest(requestType, body);
-            Console.WriteLine("");
         }
 
         static int Main()
         {            
             // use a ConsoleLogger as our logger
-            ILogger logger = new ConsoleLogger();
+            ILogger logger = new ConsoleLogger(true);
             try
             {
                 /*
@@ -46,17 +45,12 @@ namespace BM_RCON
                 {
                     throw new Exception("Failed to connect to the server");
                 }
-                logger.Log("");
-
-                // enable mutators on server if not enabled
-                sendRequest(rcon_obj, RequestType.command, "enablemutators");
 
                 RCON_Event evt;
                 while (true)
                 {
                     // receive the latest event
                     evt = rcon_obj.ReceiveEvent();
-                    logger.Log("");
 
                     // check if somebody type something in the chat
                     if (evt.EventID == (short)EventType.chat_message)
@@ -97,8 +91,8 @@ namespace BM_RCON
             // if something goes wrong, you will end up here
             catch (Exception e)
             {
-                logger.Error(e.ToString());
-                logger.Error("Something went wrong in the main.");
+                logger.Fatal(e.ToString());
+                logger.Fatal("Something went wrong in the main.");
             }
 
             // press 'Enter' to exit the console

--- a/BM-RCON/Program.cs
+++ b/BM-RCON/Program.cs
@@ -41,7 +41,11 @@ namespace BM_RCON
                 // init rcon object with address, port, password and logger
                 RCON_Client rcon_obj = new RCON_Client(addr, port, body, logger);
                 // connect the rcon client to addr:port with body
-                rcon_obj.Connect();
+                int status = rcon_obj.Connect();
+                if (status == 1)
+                {
+                    throw new Exception("Failed to connect to the server");
+                }
                 logger.Log("");
 
                 // enable mutators on server if not enabled
@@ -93,8 +97,8 @@ namespace BM_RCON
             // if something goes wrong, you will end up here
             catch (Exception e)
             {
-                logger.LogError(e.ToString());
-                logger.LogError("Something went wrong in the main.");
+                logger.Error(e.ToString());
+                logger.Error("Something went wrong in the main.");
             }
 
             // press 'Enter' to exit the console


### PR DESCRIPTION
- Update ILogger and ConsoleLogger so it uses the *classic* log levels: Trace, Debug, Info, Warning, Error, Fatal
- Rename LogDebug, LogInfo, LogWarning, LogError to Debug, Info, Warning, Error
- Add Trace and Debug logging to RCON_Client and RCON_Event
- When Trace is enabled and Debug isn't, all Debug logs become Trace logs
- Update example
- Update the documentation